### PR TITLE
Don't fail when there are > 16 results when using a callback

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "author": "substack",
   "license": "BSD",
   "dependencies": {
+    "concat-stream": "^1.6.0",
     "hyperlog-index": "^5.0.1",
     "inherits": "^2.0.1",
     "read-only-stream": "^2.0.0",


### PR DESCRIPTION
When using a callback instead of a stream to get `list` values out, the results accumulate in the internal `through` stream, and `cb` is called with those results when the through stream flushes. However, when the default high watermark of the through stream is hit (16), the underlying read stream receives bacpressure and stops emitting data. Since there is no consumer for the through stream in the callback case, the whole API call stalls out.

This PR makes the callback case use a `concat-stream` to collect results.